### PR TITLE
test: add include extraction test

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -71,3 +71,15 @@ pub fn extract_includes(file_path: &str) -> (Vec<String>, Vec<String>) {
 
     (system_includes, user_includes)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_includes() {
+        let (system_includes, user_includes) = extract_includes("tests/test_files/test.cpp");
+        assert_eq!(system_includes, vec!["iostream"]);
+        assert_eq!(user_includes, vec!["test.h"]);
+    }
+}

--- a/tests/test_files/test.cpp
+++ b/tests/test_files/test.cpp
@@ -1,0 +1,2 @@
+#include <iostream>
+#include "test.h"


### PR DESCRIPTION
Add a basic test for extracting included headers from a C/C++ file using tree-sitter, and distinguishing between user and system include types.
