### PR TITLE
fix: normalize haskell libraries that have no version component

### DIFF
--- a/python/dapper_python/normalize.py
+++ b/python/dapper_python/normalize.py
@@ -136,6 +136,9 @@ def normalize_haskell(soname: str) -> (str, Optional[str], bool):
         api_hash = name.rsplit('-', 1)[-1]
         if len(api_hash) in [20, 21, 22] and api_hash.isalnum():
             name = name[:-(len(api_hash) + 1)]
-        name, version = name.rsplit('-', 1)
-        return f"{name}.so", version, True
+        if '-' in name:
+            name, version = name.rsplit('-', 1)
+            return f"{name}.so", version, True
+        else:
+            return f"{name}.so", None, True
     return soname, None, False

--- a/python/tests/test_normalize.py
+++ b/python/tests/test_normalize.py
@@ -68,6 +68,7 @@ def test_haskell_normalization():
         ("libHSAgda-2.6.3-F91ij4KwIR0JAPMMfugHqV-ghc9.4.7.so", "libHSAgda.so", "2.6.3", None, True),
         ("libHScpphs-1.20.9.1-1LyMg8r2jodFb2rhIiKke-ghc9.4.7.so", "libHScpphs.so", "1.20.9.1", None, True),
         ("libHSrts-1.0.2_thr_debug-ghc9.4.7.so", "libHSrts.so", "1.0.2_thr_debug", None, True),
+        ("libHSrts-ghc8.6.5.so", "libHSrts.so", None, None, True)
     ]
     do_soname_normalization_tests(test_cases)
 


### PR DESCRIPTION
Some Haskell library names (libHS prefix) may only have the suffix denoting the ghc compiler version used (e.g. -ghc8.6.5).

This fixes a bug in the Python implementation of the Haskell name normalization.
Corresponds to PR #46 which fixed the same issue in the Rust library.

This change adds a test to check that this case is normalized correctly, and fixes the normalization function to treat the version number component as optional.