### PR TITLE
Dapper-Python NormalizedFileName modification

### DIFF
--- a/python/dapper_python/normalize.py
+++ b/python/dapper_python/normalize.py
@@ -1,6 +1,11 @@
 import re
+
+from dataclasses import dataclass
+
 from typing import Optional, Union
 
+
+@dataclass
 class NormalizedFileName:
     """
     Represents a normalized file name with optional version and SOABI information.
@@ -11,11 +16,13 @@ class NormalizedFileName:
         soabi (Optional[str]): The SOABI version, if available.
         normalized (bool): Indicates if the file name was normalized.
     """
-    def __init__(self, name: str, version: Optional[str] = None, soabi: Optional[str] = None, normalized: bool = False):
-        self.name = name
-        self.version = version
-        self.soabi = soabi
-        self.normalized = normalized
+    name: str
+    version: Optional[str] = None
+    soabi: Optional[str] = None
+    normalized: bool = False
+
+    def __str__(self) -> str:
+        return self.name
 
 def normalize_file_name(name: str) -> Union[NormalizedFileName, str]:
     """


### PR DESCRIPTION
Changes the `NormalizedFileName` class into a dataclass to reduce some boilerplate and add additional builtin functionality of dataclasses (automatic repr, etc)

Adds `__str__` to return the name to make it simpler to get the normalized filename.
If a user just wants the normalized name but doesn't care to check the other info, they can now use `str(normalize_file_name(file))` and will return the name string regardless of whether `normalize_file_name` returns a string or instance of `NormalizedFileName`