### PR TITLE
docs: add dataset list file to RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,3 +59,9 @@ napoleon_numpy_docstring = True
 #html_favicon = html_logo
 html_sidebars = {"**": ["globaltoc.html", "relations.html", "searchbox.html"]}
 html_static_path = ["_static"]
+
+# -------------------------------------------------------------------
+# Make dataset_list.toml available as a static file at the site root
+# https://surfactant.readthedocs.io/en/latest/dataset_list.toml
+# -------------------------------------------------------------------
+html_extra_path = ["dataset_list.toml"]

--- a/docs/dataset_list.toml
+++ b/docs/dataset_list.toml
@@ -1,0 +1,3 @@
+[metadata]
+version = "1.0"
+last_updated = "2025-05-17"


### PR DESCRIPTION
Related to #13 -- adds a file to the ReadTheDocs site that will be fetched as part of downloading/installing datasets, in order to get a list of all the available datasets that can be downloaded.