### PR TITLE
fix: open datasets as read only

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-use rusqlite;
+use rusqlite::{self, OpenFlags};
 use rusqlite::{CachedStatement, Connection, Statement};
 use std::path::Path;
 
@@ -14,7 +14,12 @@ pub struct Database {
 impl Database {
     ///Create database object from sqlite file at the provided path
     pub fn new(path: &Path) -> rusqlite::Result<Database> {
-        let connection = Connection::open(path)?;
+        let connection = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY
+                | OpenFlags::SQLITE_OPEN_URI
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
         Ok(Database { connection })
     }
 


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will update the Database connection function so that database files are read only. If the database does not exist, a new one will not be created. 


