### PR TITLE
chore(python): bump version number to 0.0.0.dev2

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dapper-python"
-version = "0.0.0.dev1"
+version = "0.0.0.dev2"
 description = "A Python package for interacting with DAPper datasets"
 authors = [
     { name = "Ryan Mast", email = "mast9@llnl.gov" }


### PR DESCRIPTION
Bump the pypi helper package version for a new release.