### PR TITLE
chore: bump dapper version to 0.0.0-pre.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dapper"
-version = "0.0.0-pre.2"
+version = "0.0.0-pre.3"
 edition = "2021"
 license = "MIT"
 description = "Dependency Analysis Project - identifying dependencies in C/C++ code and packages on filesystems"


### PR DESCRIPTION
Bump the dapper version for a new release on crates.io