### PR TITLE
chore: bump version in Cargo.lock to 0.0.0-pre.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "dapper"
-version = "0.0.0-pre.2"
+version = "0.0.0-pre.3"
 dependencies = [
  "cc",
  "chrono",


### PR DESCRIPTION
Another version number to bump for a clean release on crates.io