### PR TITLE
chore(python): bump version number to 0.0.0.dev3

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dapper-python"
-version = "0.0.0.dev2"
+version = "0.0.0.dev3"
 description = "A Python package for interacting with DAPper datasets"
 authors = [
     { name = "Ryan Mast", email = "mast9@llnl.gov" }


### PR DESCRIPTION
Pushing another version of the PyPI package with some typing-extension fallbacks for older Python versions.